### PR TITLE
Support temperature and top_p parameters

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,16 @@ pub(crate) struct CompletionArgs {
     pub max_tokens: Option<u16>,
 
     /// Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
-    #[arg(short = 't', long)]
+    #[arg(long)]
     pub stop: Vec<String>,
+
+    /// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+    #[arg(short, long, default_value_t = 0.7)]
+    pub temperature: f32,
+
+    ///An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+    #[arg(long, default_value_t = 1.0)]
+    pub top_p: f32,
 
     /// For chat completions, you can specify a system message to be sent to the model.
     /// This message will be sent to the model before the user's message.

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -44,6 +44,7 @@ pub(crate) async fn chat_completion(
 ) -> anyhow::Result<()> {
     let request = &mut CreateChatCompletionRequestArgs::default();
     let request = request.model(model);
+    let request = request.temperature(cli.temperature).top_p(cli.top_p);
 
     let mut messages = vec![ChatCompletionRequestMessageArgs::default()
         .content(prompt)
@@ -99,6 +100,7 @@ pub(crate) async fn completion(
     cli: &CompletionArgs,
 ) -> anyhow::Result<()> {
     let request = &mut CreateCompletionRequestArgs::default();
+    let request = request.temperature(cli.temperature).top_p(cli.top_p);
 
     let mut prompt = prompt.to_string();
     if let Some(system_message) = &cli.system_message {


### PR DESCRIPTION
Enable users to set `temperature` and `top_p` parameters


See [https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature](https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature) and [https://platform.openai.com/docs/api-reference/chat/create#chat/create-top_p](https://platform.openai.com/docs/api-reference/chat/create#chat/create-top_p)