### PR TITLE
chore: Update third party dependencies versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "async-openai"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c791cd9568241317f49bb3e3a6b595c986a2022428caa16a316be2520d05acf1"
+checksum = "f055d4e6286ba63bdbc4b48f2f72a00d957096726a9425640b5b24caa417d558"
 dependencies = [
  "backoff",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.69"
-async-openai = "0.8.0"
+async-openai = "0.9.2"
 backoff = { version = "0.4.0", features = ["tokio"] }
 clap = { version = "4.1.8", features = ["derive"] }
 futures = "0.3.26"
 tempfile = "3.4.0"
-tiktoken-rs = "0.1.2"
+tiktoken-rs = "0.1.4"
 tokio = {version = "1.26.0", features = ["full"]}
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"]}


### PR DESCRIPTION
- Update dependencies for async-openai and tiktoken-rs to latest versions.